### PR TITLE
Aptur compatibility with finalizeOrbits

### DIFF
--- a/GameData/New_Horizons/KopernicusFiles/NewHorizonPlanets/Aptur/Aptur.cfg
+++ b/GameData/New_Horizons/KopernicusFiles/NewHorizonPlanets/Aptur/Aptur.cfg
@@ -131,3 +131,14 @@
 		}
 	}
 }
+
+@Kopernicus:HAS[@Finalize:HAS[#finalizeOrbits[?rue]]]:FINAL
+{
+	@Body[Aptur]
+	{
+		@Orbit
+		{
+			@semiMajorAxis = 51658287.7998986
+		}
+	}
+}


### PR DESCRIPTION
this should work as long as finalizeOrbits is added before the aptur config

I used rounded values for kerbin's mass. so the semimajoraxis may need to be fixed

formula is:

x^3 = a^3 \* (m1+m3)/(m1+m2)

where

x = Aptur SMA
a = Kerbin SMA
m1 = Sonnah mass
m2 = Kerbin mass
m3 = Aptur mass
